### PR TITLE
Fix autosplitter for current version of Dicey Dungeons

### DIFF
--- a/Components/Updates.xml
+++ b/Components/Updates.xml
@@ -8,4 +8,12 @@
 			<change> Initial Release </change>
 		</changelog>
 	</update>
+  <update version="1.1.0">
+    <files>
+      <file path="Components/LiveSplit.DiceyDungeons.dll" status="changed"/>
+    </files>
+    <changelog>
+      <change> Updated floor autosplit and boss autosplit to work properly with v1.12.2, 25-10-2021, STEAM, 64-bit, GL version </change>
+    </changelog>
+  </update>
 </updates>

--- a/LiveSplit.DiceyDungeons.csproj
+++ b/LiveSplit.DiceyDungeons.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LiveSplit.DiceyDungeons</RootNamespace>
     <AssemblyName>LiveSplit.DiceyDungeons</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -2,18 +2,16 @@
 using LiveSplit.UI.Components;
 using System.Reflection;
 using System.Runtime.InteropServices;
-[assembly: AssemblyTitle("LiveSplit.JumpKing")]
-[assembly: AssemblyDescription("Autosplitter for Jump King")]
+[assembly: AssemblyTitle("LiveSplit.DiceyDungeons")]
+[assembly: AssemblyDescription("Autosplitter for Dicey Dungeons")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("LiveSplit.JumpKing")]
+[assembly: AssemblyProduct("LiveSplit.DiceyDungeons")]
 [assembly: AssemblyCopyright("Copyright ©  2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("b3294e28-2bd4-4e39-92fa-e04a620c7aaa")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
-#if !DebugInfo
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.1.0")]
 [assembly: ComponentFactory(typeof(SplitterFactory))]
-#endif

--- a/SplitterMemory.cs
+++ b/SplitterMemory.cs
@@ -3,8 +3,8 @@ using System;
 using System.Diagnostics;
 namespace LiveSplit.DiceyDungeons {
 	public enum Player {
-		User = 0x1b25f00,
-		Enemy = 0x1b25f08
+		User = 0x1cbc7f8,
+		Enemy = 0x1cbc800
 	}
 	public partial class SplitterMemory {
 		public Process Program { get; set; }
@@ -56,10 +56,10 @@ namespace LiveSplit.DiceyDungeons {
 			return PlayerXPNeeded() - Program.Read<int>(BaseAddress, 0x1b1a908);
 		}
 		public int PlayerXPNeeded() {
-			return Program.Read<int>(BaseAddress, 0x1b1a90c);
+			return Program.Read<int>(BaseAddress, 0x1cb0938);
 		}
 		public int Floor() {
-			return Program.Read<int>(BaseAddress, 0x1b25ecc) + 1;
+			return Program.Read<int>(BaseAddress, 0x1cbc778) + 1;
 		}
 		public bool HookProcess() {
 			IsHooked = Program != null && !Program.HasExited;


### PR DESCRIPTION
This PR:

- updates the assembly info, which apparently said "Jump King" instead of "Dicey Dungeons"
- Sets target framework to 4.6.1 to be in sync with LiveSplit build version.
- Updates the player enum with the right player and enemy values, and also set the right value for the floor

So far the autosplitter works on my side, using v1.12.2, 25-10-2021, STEAM, 64-bit, GL version on Windows 10. I verified that the new autosplitter works by completing a run of Warrior episode 1 and testing whether the game split when going down a floor or beating the boss. I think we need to check to see if this PR works on other machines.